### PR TITLE
Deprecated long option fix

### DIFF
--- a/lib/vagrant-multipass/action/clone.rb
+++ b/lib/vagrant-multipass/action/clone.rb
@@ -103,7 +103,7 @@ module VagrantPlugins
             end
 
             unless config.memory_mb.nil?
-              multipass_cmd << '--mem'
+              multipass_cmd << '--memory'
               multipass_cmd << "#{config.memory_mb}M"
             end
 


### PR DESCRIPTION
In multipass 1.15 the `--mem` command line long option has been deprecated in favor of the `--memory` option.

This PR fixes this issue and has been verified to work.